### PR TITLE
Added license to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,7 @@
     "description": "Directive for use with ngAnimate and ui-router, providing events between transition phases",
     "version": "0.0.14",
     "main": "anim-in-out.js",
+    "license": "MIT",
     "ignore": [
         "*",
         "!anim-in-out.js",


### PR DESCRIPTION
The license may be automatically detected now. For example using grunt-license-bower task.