### PR TITLE
Add file extensions in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,8 +4,8 @@
   "version": "1.0.1",
   "main": [
     "anim-in-out.js",
-    "css/anim-in-out",
-    "scss/anim-in-out"
+    "css/anim-in-out.css",
+    "scss/anim-in-out.scss"
   ],
   "license": "MIT",
   "ignore": [


### PR DESCRIPTION
In `bower.json`, the `main` object represents selected files in bower. There are three elements in `main` object, `anim-in-out.js`, `css/anim-in-out` and `scss/anim-in-out`. However, it seems like `css/anim-in-out` and `scss/anim-in-out` don't contain file extensions, `.css` and `.scss`. It may result automatic building tools cannot find correct files.
